### PR TITLE
handle missing servers.txt: non-existent file throws IOError

### DIFF
--- a/www/index.html.spt
+++ b/www/index.html.spt
@@ -6,7 +6,7 @@ servers_txt = os.path.join(website.project_root, 'servers.txt')
 
 try:
     servers = open(servers_txt).read().splitlines()
-except OSError:
+except IOError:
     servers = ['localhost']
 servers.sort()
 


### PR DESCRIPTION
At least on my machine.
