### PR TITLE
Pin to Python 2 in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 env:
 	unzip -q -d vendor/virtualenv vendor/virtualenv*.whl
-	python ./vendor/virtualenv/virtualenv.py \
+	python2 ./vendor/virtualenv/virtualenv.py \
 				--prompt="[mongs] " \
 				./env/
 	rm -R vendor/virtualenv

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 env:
 	unzip -q -d vendor/virtualenv vendor/virtualenv*.whl
-	python2 ./vendor/virtualenv/virtualenv.py \
+	python ./vendor/virtualenv/virtualenv.py --python=python2.7 \
 				--prompt="[mongs] " \
 				./env/
 	rm -R vendor/virtualenv


### PR DESCRIPTION
I have `python` as Python 3 on my system, so `make env` creates a Python 3 virtualenv. We're blocking on Aspen/Pando (https://github.com/AspenWeb/pando.py/issues/493) to upgrade to Python 3, so for now let's enforce Python 2.

Look okay, @jaraco?