### PR TITLE
Relax _id matching

### DIFF
--- a/mongs.py
+++ b/mongs.py
@@ -24,6 +24,19 @@ def commaize(n, places=1):
     return out
 
 
+def get_single_document_filter(_id):
+    filter = {"_id": {"$in": [_id]}}
+    try:
+        # Under some combination of MongoDB/PyMongo versions, this is
+        # necessary.
+        object_id = ObjectId(_id)
+    except InvalidId:
+        pass
+    else:
+        filter['_id']['$in'].append(object_id)
+    return filter
+
+
 def get_value(request):
     """Given a request object, return a value. Use for *.txt and *.json.
     """
@@ -34,12 +47,8 @@ def get_value(request):
     key = request.line.uri.path['value'] # derp
 
     db = pymongo.MongoClient(server)[database][collection]
-
-    try:
-        _id = ObjectId(_id)
-    except InvalidId:
-        pass
-    document = db.find_one(_id)
+    filter = get_single_document_filter(_id)
+    document = db.find_one(filter)
     return document[key]
 
 

--- a/www/%server/%database/%collection/%filter/index.html.spt
+++ b/www/%server/%database/%collection/%filter/index.html.spt
@@ -105,11 +105,15 @@ else:               # /server/database/collection/_id/
     page = 1
     base = '..'
     _id = filter
+    filter = {"_id": {"$in": [_id]}}
     try:
-        _id = ObjectId(_id)
+        # Under some combination of MongoDB/PyMongo versions, this is
+        # necessary.
+        object_id = ObjectId(_id)
     except InvalidId:
         pass
-    filter = {"_id": _id}
+    else:
+        filter['_id']['$in'].append(object_id)
 
 
 # Sort.

--- a/www/%server/%database/%collection/%filter/index.html.spt
+++ b/www/%server/%database/%collection/%filter/index.html.spt
@@ -104,16 +104,7 @@ else:               # /server/database/collection/_id/
     # Convert a request for a specific _id into a filter with one page.
     page = 1
     base = '..'
-    _id = filter
-    filter = {"_id": {"$in": [_id]}}
-    try:
-        # Under some combination of MongoDB/PyMongo versions, this is
-        # necessary.
-        object_id = ObjectId(_id)
-    except InvalidId:
-        pass
-    else:
-        filter['_id']['$in'].append(object_id)
+    filter = mongs.get_single_document_filter(filter)
 
 
 # Sort.


### PR DESCRIPTION
I am finding this necessary in my current environment. Without it, I am seeing a 404 from single document pages.

```
[mongs] $ mongod --version
TokuMX mongod server v2.0.0-mongodb-2.4.10, using TokuKV rev 60be90af92bb3aeae3e43fe166e8d4381a1e5e7c
Tue Jul 26 13:50:32.582 git version: 534df238ab437147e722c6ff6b3ad535991bfc8b
[mongs] $ python -c 'import pymongo; print(pymongo.__version__)'
3.2.2
```

Ready for review, @jaraco.