### PR TITLE
Use json_util.default from pymongo to safely encode datetime types.

### DIFF
--- a/www/%server/%database/%collection/%filter/%value.json.spt
+++ b/www/%server/%database/%collection/%filter/%value.json.spt
@@ -1,5 +1,7 @@
 import json
 
+from bson import json_util
+
 import mongs
 [---]
 value = mongs.get_value(request)
@@ -8,6 +10,6 @@ if isinstance(value, basestring):
     # JSON prettifier doesn't choke.
     path, ext, _ = request.line.uri.path.raw.rpartition('.json')
     request.redirect(path + ".txt")
-response.body = json.dumps(value)
+response.body = json.dumps(value, default=json_util.default)
 raise response
 [---]


### PR DESCRIPTION
Fixes #34.