### PR TITLE
Honor SERVER_URIS when connecting to database

### DIFF
--- a/mongs.py
+++ b/mongs.py
@@ -48,7 +48,8 @@ def get_value(request):
     _id = request.path['filter']
     key = request.path['value']  # derp
 
-    db = pymongo.MongoClient(server)[database][collection]
+    client = connect(server)
+    db = client[database][collection]
     filter = get_single_document_filter(_id)
     document = db.find_one(filter)
     return document[key]


### PR DESCRIPTION
Calling `get_value()` was connecting to Mongo bypassing SERVER_URIS.